### PR TITLE
Update package.json - require node 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/CorantGmbH/ioBroker.air-q.git"
   },
   "engines": {
-    "node": ">= 16"
+    "node": ">= 18"
   },
   "dependencies": {
     "@iobroker/adapter-core": "^3.1.0",


### PR DESCRIPTION
As this adapter is no longer tested using node 16 it should require node 18 minimum.

Please check and merge.