### PR TITLE
Update node requirement and dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "@iobroker/adapter-core": "^3.1.0",
+        "@iobroker/adapter-core": "^3.1.4",
         "bonjour-service": "^1.2.1",
         "crypto-js": "^4.2.0"
       },
@@ -19,7 +19,7 @@
         "@alcalzone/release-script-plugin-license": "^3.7.0",
         "@alcalzone/release-script-plugin-manual-review": "^3.7.0",
         "@iobroker/adapter-dev": "^1.2.0",
-        "@iobroker/testing": "github:iobroker/testing",
+        "@iobroker/testing": "^4.1.3",
         "@tsconfig/node16": "^16.1.3",
         "@types/chai": "^4.3.6",
         "@types/chai-as-promised": "^7.1.8",
@@ -45,7 +45,7 @@
         "typescript": "~5.4.5"
       },
       "engines": {
-        "node": ">= 16"
+        "node": ">= 18"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -805,9 +805,9 @@
       "dev": true
     },
     "node_modules/@iobroker/adapter-core": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@iobroker/adapter-core/-/adapter-core-3.1.0.tgz",
-      "integrity": "sha512-//XeBqMzVWIPelJYiIXalxRMtvMbY7S5XOFQbSjwG0YqX0wgobWmbJk1hGd/qGVUYzhY+SKNJ3nAbjB+28bd0w==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@iobroker/adapter-core/-/adapter-core-3.1.4.tgz",
+      "integrity": "sha512-RYDGB8Vk/MEKvMMwo4fLgxY8kjHrCeQmqROo/JxQYiLBEA4/gwFCTpxdD6s7RQ+dh4yZoH16/yTWqdgyR6NAxQ==",
       "engines": {
         "npm": ">=7.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     "url": "https://github.com/CorantGmbH/ioBroker.air-q.git"
   },
   "engines": {
-    "node": ">= 16"
+    "node": ">= 18"
   },
   "dependencies": {
-    "@iobroker/adapter-core": "^3.1.0",
+    "@iobroker/adapter-core": "^3.1.4",
     "bonjour-service": "^1.2.1",
     "crypto-js": "^4.2.0"
   },
@@ -33,7 +33,7 @@
     "@alcalzone/release-script-plugin-license": "^3.7.0",
     "@alcalzone/release-script-plugin-manual-review": "^3.7.0",
     "@iobroker/adapter-dev": "^1.2.0",
-    "@iobroker/testing": "github:iobroker/testing",
+    "@iobroker/testing": "^4.1.3",
     "@tsconfig/node16": "^16.1.3",
     "@types/chai": "^4.3.6",
     "@types/chai-as-promised": "^7.1.8",


### PR DESCRIPTION
As this adapter is no longer tested using noce 16 (which is OK) it should require node 18 minimum.

In addtion please avoid dependencies into github unless absolutly required. Dependencies to adapter-core and testing have been updated.

Please check and merge. If you have any questions, please let me know.